### PR TITLE
Serve jquery over https

### DIFF
--- a/theme/webcomic_theme_4.0.html
+++ b/theme/webcomic_theme_4.0.html
@@ -533,7 +533,7 @@ http://www.gnu.org/licenses/gpl-2.0.html
 	<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 	<script src="http://ie7-js.googlecode.com/svn/version/2.1(beta4)/IE9.js"></script>
 	<![endif]-->
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 
 	<script>
 	var SWCTheme = new function() {


### PR DESCRIPTION
If Tumblr's "Always serve blog over SSL" setting is enabled then jquery needs to be served over SSL to work. Otherwise theme features like top pagination don't function correctly. See: [https://www.tumblr.com/docs/en/account_security#ssl_theme](https://www.tumblr.com/docs/en/account_security#ssl_theme)